### PR TITLE
Develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ bun run dev
 | `test:watch`    | 워치 모드 테스트            |
 | `test:ui`       | 브라우저 UI 테스트          |
 | `test:coverage` | 커버리지 리포트 생성        |
+| `test:e2e`      | E2E 테스트 실행 (Playwright) |
+| `test:e2e:ui`   | E2E 테스트 UI 모드 실행     |
+| `test:e2e:report` | E2E 테스트 결과 리포트 보기 |
 | `lint`          | ESLint 실행                 |
 | `lint:fix`      | ESLint 오류 자동 수정       |
 | `format`        | Prettier로 코드 포맷팅      |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -12,6 +12,7 @@ docs/         # 프로젝트 문서
 licenses/     # 서드파티 라이선스 정보
 public/       # 정적 에셋 (이미지, 파비콘 등)
 src/          # 애플리케이션 소스 코드
+tests-e2e/    # Playwright E2E 테스트
 ```
 
 ## `src` 디렉터리 상세 구조

--- a/package.json
+++ b/package.json
@@ -92,7 +92,8 @@
     "postinstall": [
       "bunx rimraf -rf .git",
       "bunx rimraf -rf dist",
-      "bunx rimraf -rf LICENSE"
+      "bunx rimraf -rf LICENSE",
+      "echo '경고: LICENSE 파일이 제거되었습니다. 새 프로젝트에 맞는 라이선스를 추가하세요.'"
     ],
     "start": "bun run dev"
   }

--- a/package.json
+++ b/package.json
@@ -91,7 +91,8 @@
     "preinstall": [],
     "postinstall": [
       "bunx rimraf -rf .git",
-      "bunx rimraf -rf dist"
+      "bunx rimraf -rf dist",
+      "bunx rimraf -rf LICENSE"
     ],
     "start": "bun run dev"
   }


### PR DESCRIPTION
E2E 테스트 명령어: Playwright 기반의 E2E 테스트를 실행하고, UI를 확인하며, 테스트 결과를 리포트할 수 있는 새로운 bun 명령어들이 README.md에 추가되었습니다.

프로젝트 구조 문서화: docs/architecture.md 파일이 업데이트되어, 프로젝트 전체 구조에 tests-e2e/ 디렉토리가 포함되도록 반영되었습니다.

설치 후 정리 작업: package.json의 postinstall 스크립트에 설치 후 LICENSE 파일을 자동으로 삭제하는 단계가 추가되었습니다.